### PR TITLE
Don't download the binary if it's an existing installation

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -45,6 +45,7 @@
     dest: "/tmp/{{ splunkforwarder_filename }}"
     mode: 0775
     checksum: "{{ splunkforwarder_md5 }}"
+  when: splunk_path.stat.exists == false
 
 - name: install splunk binary
   become: yes


### PR DESCRIPTION
Removing the overhead of downloading the Splunk Forwarder binary on each run if Splunk is already installed.